### PR TITLE
Ansible Collections using "message" as parameters can fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ CAUTION ⚠ removes files and folders - recursive!
 ```yml
 - name: send hello
   markuman.nextcloud.talk:
-    message: Ho Hi from Ansible.
+    msg: Ho Hi from Ansible.
     channel: 8fyrb4ec
 ```
 

--- a/plugins/lookup/passwords.py
+++ b/plugins/lookup/passwords.py
@@ -64,7 +64,7 @@ class LookupModule(LookupBase):
                 if r.status_code == 200:
                     for item in r.json():
                         if item['label'] == term:
-                            ret.append(item['password'])
+                            ret.append(item)
                 else:
                     raise AnsibleParserError()
             except AnsibleParserError:

--- a/plugins/modules/talk.py
+++ b/plugins/modules/talk.py
@@ -30,7 +30,7 @@ options:
       - Can also be set as ENV variable.
     required: false
     type: str
-  message:
+  msg:
     description:
       - Message that will be send.
     required: true
@@ -45,7 +45,7 @@ options:
 EXAMPLES = '''
     - name: send hello
       markuman.nextcloud.talk:
-        message: Ho Hi!
+        msg: Ho Hi!
         channel: someid
 '''
 
@@ -57,7 +57,7 @@ import json
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            message = dict(required=True, type='str'),
+            msg = dict(required=True, type='str'),
             channel = dict(required=True, type='str'),
             host = dict(required=False, type='str'),
             user = dict(required=False, type='str'),
@@ -67,7 +67,7 @@ def main():
 
     nc = NextcloudHandler(module.params)
 
-    message = module.params.get("message")
+    msg = module.params.get("msg")
     channel = module.params.get("channel")
 
     headers = {
@@ -76,13 +76,13 @@ def main():
     }
 
     body = {
-        'message': message,
+        'message': msg,
         'replyTo': 0
     }
 
-    r, change = nc.talk(message, channel)
+    r, change = nc.talk(msg, channel)
 
-    module.exit_json(changed = change, talk={'message': message, 'channel': channel})
+    module.exit_json(changed = change, talk={'message': msg, 'channel': channel})
     
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Markus,

at first, thanks for this pretty handy collection. I tried to use it with ansible 4. While playing with it, i realized that the talk method was not working.  I was facing the following error:

    Traceback (most recent call last):
      File "/home/stevg/.ansible/tmp/ansible-tmp-1623140357.3210704-1162578-18247537908204/AnsiballZ_talk.py", line 100, in <module>
        _ansiballz_main()
      File "/home/stevg/.ansible/tmp/ansible-tmp-1623140357.3210704-1162578-18247537908204/AnsiballZ_talk.py", line 92, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/stevg/.ansible/tmp/ansible-tmp-1623140357.3210704-1162578-18247537908204/AnsiballZ_talk.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.markuman.nextcloud.plugins.modules.talk', init_globals=dict(_module_fqn='ansible_collections.markuman.nextcloud.plugins.modules.talk', _modlib_path=modlib_path),
      File "/usr/lib64/python3.9/runpy.py", line 210, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib64/python3.9/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_markuman.nextcloud.talk_payload_l4frj0qu/ansible_markuman.nextcloud.talk_payload.zip/ansible_collections/markuman/nextcloud/plugins/modules/talk.py", line 89, in <module>
      File "/tmp/ansible_markuman.nextcloud.talk_payload_l4frj0qu/ansible_markuman.nextcloud.talk_payload.zip/ansible_collections/markuman/nextcloud/plugins/modules/talk.py", line 58, in main
      File "/tmp/ansible_markuman.nextcloud.talk_payload_l4frj0qu/ansible_markuman.nextcloud.talk_payload.zip/ansible/module_utils/basic.py", line 523, in __init__
      File "/tmp/ansible_markuman.nextcloud.talk_payload_l4frj0qu/ansible_markuman.nextcloud.talk_payload.zip/ansible/module_utils/basic.py", line 1384, in _log_invocation
      File "/tmp/ansible_markuman.nextcloud.talk_payload_l4frj0qu/ansible_markuman.nextcloud.talk_payload.zip/ansible/module_utils/basic.py", line 1341, in log
    TypeError: systemd.journal.send() got multiple values for keyword argument 'MESSAGE'

While googling for it i found 2 Issues in the ansible main repository which are referencing this error in combinations with other collections. I decided to fork your collection and simply changed the message parameter to msg. Everything is working for me now. 

Thanks again!